### PR TITLE
[FEATURE] extend SecAuditLogParts with 'k' to retrieve the matched rules

### DIFF
--- a/mutatingwebhook.go
+++ b/mutatingwebhook.go
@@ -75,6 +75,7 @@ func enableWAF(ingress *networkingv1.Ingress) error {
 	ingress.Annotations["nginx.ingress.kubernetes.io/modsecurity-snippet"] = `
 SecRuleEngine On
 SecAuditLog /dev/stdout
+SecAuditLogParts ABCFHKZ
 `
 
 	requestBodyLimit, found := ingress.Annotations[AnnotationRequestBodyLimit]


### PR DESCRIPTION
When SecAuditLog is enabled, the default SecAuditLogPart setting ABCFHZ takes effect. 

This PR adds the option "K" which shows detailed output of the matched rules.

For more options see https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-(v2.x)#secauditlogparts.