### PR TITLE
Feature extend secauditlogparts output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 .env
+.idea/

--- a/mutatingwebhook.go
+++ b/mutatingwebhook.go
@@ -74,8 +74,11 @@ func enableWAF(ingress *networkingv1.Ingress) error {
 	ingress.Annotations["nginx.ingress.kubernetes.io/enable-owasp-core-rules"] = "true"
 	ingress.Annotations["nginx.ingress.kubernetes.io/modsecurity-snippet"] = `
 SecRuleEngine On
+SecAuditEngine RelevantOnly
 SecAuditLog /dev/stdout
-SecAuditLogParts ABCFHKZ
+SecAuditLogParts ABCEFHJZ
+SecAction "id:900110,phase:1,log,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=10"
+SecAction "phase:5,auditlog,log,pass,msg:\'Anomaly Score %{TX.anomaly_score} Threshold %{TX.inbound_anomaly_score_threshold}\'"
 `
 
 	requestBodyLimit, found := ingress.Annotations[AnnotationRequestBodyLimit]

--- a/mutatingwebhook.go
+++ b/mutatingwebhook.go
@@ -75,6 +75,7 @@ func enableWAF(ingress *networkingv1.Ingress) error {
 	ingress.Annotations["nginx.ingress.kubernetes.io/modsecurity-snippet"] = `
 SecRuleEngine On
 SecAuditLog /dev/stdout
+SecAuditLogParts ABCFHKZ
 `
 
 	requestBodyLimit, found := ingress.Annotations[AnnotationRequestBodyLimit]


### PR DESCRIPTION
This Pull Request adds more the LogOutput Levels "E" & "J" and changes the default thresold from 5 to 10.

Furthermore it adds an action in phase 5, which displays the current anomaly score including the threshold value.